### PR TITLE
feat: Filter Monarch Transactions by Merchant Name

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,8 +16,22 @@ permissions:
   contents: read
 
 jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - run: pip install ".[dev]"
+      - run: pip test
+
   release-build:
     runs-on: ubuntu-latest
+
+    needs:
+      - unit-test
 
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +55,7 @@ jobs:
   pypi-publish:
     runs-on: ubuntu-latest
     needs:
+      - unit-test
       - release-build
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
@@ -99,4 +114,4 @@ jobs:
       run: >-
         gh release upload
         "${{ github.event.release.name }}" dist/**
-          --repo "$GITHUB_REPOSITORY"           
+          --repo "$GITHUB_REPOSITORY"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,4 +19,9 @@
         "TOTP",
         "yohtmlc"
     ],
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
 
 [project.optional-dependencies]
 build = ["twine"]
-dev = ["pre-commit", "ruff"]
+test = ["pytest", "pytest-asyncio"]
+dev = ["pre-commit", "ruff", "pytest", "pytest-asyncio", "pytest-sugar"]
 
 
 [project.urls]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files = test_*.py
+pythonpath =
+    src/

--- a/src/amazon_connector/base_connector.py
+++ b/src/amazon_connector/base_connector.py
@@ -82,7 +82,8 @@ class BaseAmazonConnector(ABC):
                 )
             else:
                 logger.warning(
-                    "No captcha solver provided. Please solve the captcha manually."
+                    "No captcha solver provided. Please solve the captcha manually. Image: {}",
+                    image_url,
                 )
             solved_captcha = input("Please enter the solved captcha: ")
             return solved_captcha

--- a/src/config/types.py
+++ b/src/config/types.py
@@ -32,6 +32,13 @@ class Debug(BaseModel):
     pause_between_navigation: bool = False
 
 
+class TransactionFilters(BaseModel):
+    merchant_name: str
+    ignore_case: bool = True
+    # Only care if the merchant name _contains_ the name.
+    search_by_contains: bool = False
+
+
 class LLM(BaseModel):
     enable_llm_captcha_solver: bool = False
     api_key: str = ""
@@ -45,6 +52,7 @@ class Config(BaseSettings):
     monarch_account: MonarchAccount
     amazon_accounts: list[AmazonAccount]
     transaction_tag: TransactionTag = TransactionTag()
+    transaction_filters: list[TransactionFilters] = []
     amazon_account_tag: AmazonAccountTag = AmazonAccountTag()
     debug: Debug = Debug()
     llm: LLM = LLM()

--- a/src/fsm/states.py
+++ b/src/fsm/states.py
@@ -27,7 +27,6 @@ class State(ABC):
 
         except Exception as e:
             logger.error(f"Error in state {self.__class__.__name__}: {e}")
-            state_machine.error_occurred()
 
     @abstractmethod
     def _handle(

--- a/tests/monarch/test_monarch_connector.py
+++ b/tests/monarch/test_monarch_connector.py
@@ -1,0 +1,185 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from typing import List
+from src.config.types import MonarchAccount, TransactionFilters
+from src.monarch_connector.monarch import MonarchConnector, Transaction, Config
+from src.monarch_connector.api_types import (
+    AllTransactions,
+    Category,
+    Merchant,
+    TransactionResponse,
+    TransactionTag,
+)
+
+
+class TestGetTransactionsNeedReview:
+    """
+    Test suite for the `get_transactions_need_review` method.
+    """
+
+    # Arrange: Set up mock data for transactions
+    _mock_transactions = [
+        Transaction(
+            id="1",
+            amount=100.0,
+            pending=False,
+            date="2024-01-01",
+            hideFromReports=False,
+            plaidName="Grocery Store",
+            notes=None,
+            isRecurring=False,
+            reviewStatus="needs_review",
+            needsReview=True,
+            attachments=[],
+            isSplitTransaction=False,
+            createdAt="2024-01-01",
+            updatedAt="2024-01-01",
+            category=Category(id="", name=""),
+            merchant=Merchant(id="m1", name="Grocery Store", transactionsCount=0),
+            account={},
+            tags=[TransactionTag(id="tag1", name="Important", color="", order=-1)],
+        ),
+        Transaction(
+            id="2",
+            amount=200.0,
+            pending=False,
+            date="2024-01-02",
+            hideFromReports=False,
+            plaidName="Coffee Shop",
+            notes=None,
+            isRecurring=False,
+            reviewStatus="needs_review",
+            needsReview=True,
+            attachments=[],
+            isSplitTransaction=False,
+            createdAt="2024-01-02",
+            updatedAt="2024-01-02",
+            category=Category(id="", name=""),
+            merchant=Merchant(id="m2", name="Coffee Shop", transactionsCount=0),
+            account={},
+            tags=[],
+        ),
+        Transaction(
+            id="3",
+            amount=150.0,
+            pending=False,
+            date="2024-01-03",
+            hideFromReports=False,
+            plaidName="Bookstore",
+            notes=None,
+            isRecurring=False,
+            reviewStatus="reviewed",
+            needsReview=False,
+            attachments=[],
+            isSplitTransaction=False,
+            createdAt="2024-01-03",
+            updatedAt="2024-01-03",
+            category=Category(id="", name=""),
+            merchant=Merchant(id="m3", name="Bookstore", transactionsCount=0),
+            account={},
+            tags=[],
+        ),
+        Transaction(
+            id="4",
+            amount=29.0,
+            pending=False,
+            date="2024-01-03",
+            hideFromReports=False,
+            plaidName="Market",
+            notes=None,
+            isRecurring=False,
+            reviewStatus="needs_review",
+            needsReview=False,
+            attachments=[],
+            isSplitTransaction=False,
+            createdAt="2024-01-03",
+            updatedAt="2024-01-03",
+            category=Category(id="", name=""),
+            merchant=Merchant(id="m4", name="Market", transactionsCount=0),
+            account={},
+            tags=[],
+        ),
+    ]
+
+    @pytest.mark.asyncio
+    async def test_cases(self):
+        """
+        Test the `get_transactions_need_review` method with multiple configurations.
+        """
+
+        # Mock the `get_transactions` method to return the mock data
+        mock_mm = MagicMock()
+
+        transactions = self._mock_transactions
+
+        async def x(limit):
+            return TransactionResponse(
+                allTransactions=AllTransactions(results=transactions)
+            )
+
+        mock_mm.get_transactions = x
+
+        # Define test configurations
+        test_configs = [
+            # Case 1: Filter by merchant name "Market"
+            Config(
+                amazon_accounts=[],
+                monarch_account=MonarchAccount(email="", password=""),
+                transaction_filters=[
+                    TransactionFilters(
+                        merchant_name="maRkeT",
+                        ignore_case=True,
+                        search_by_contains=False,
+                    )
+                ],
+            ),
+            # Case 2: No filters applied
+            Config(
+                amazon_accounts=[],
+                monarch_account=MonarchAccount(email="", password=""),
+                transaction_filters=[],
+            ),
+            # Case 3: Filter by merchant name "Grocery" (partial match, ignore case enabled)
+            Config(
+                amazon_accounts=[],
+                monarch_account=MonarchAccount(email="", password=""),
+                transaction_filters=[
+                    TransactionFilters(
+                        merchant_name="grocery",
+                        ignore_case=True,
+                        search_by_contains=True,
+                    )
+                ],
+            ),
+        ]
+
+        # Mock the `_get_mmac_tag_id` method
+        tag_id = "tag1"
+        mock_connector = MonarchConnector(
+            mock_mm, test_configs[0]
+        )  # Using first config initially
+        mock_connector._get_mmac_tag_id = AsyncMock(return_value=tag_id)
+
+        # Act & Assert: Evaluate each configuration scenario
+        expected_results = [
+            # Case 1: Only "Market" transaction matches the filter
+            [transactions[3]],
+            # Case 2: No filters, all transactions with needsReview=True and no mmac tag should be returned (Just coffee and market)
+            [transactions[1], transactions[3]],
+            # Case 3: Only "Grocery Store" matches the partial match filter, but it is tagged. So no results.
+            [],
+        ]
+
+        for i, config in enumerate(test_configs):
+            mock_connector._config = config  # Update config for the test case
+            filtered_transactions: List[
+                Transaction
+            ] = await mock_connector.get_transactions_need_review()
+
+            # Assertions
+            assert (
+                len(filtered_transactions) == len(expected_results[i])
+            ), f"Failed Test Case idx={i}. Actual != Expected ({filtered_transactions} != {expected_results[i]})"
+            for filtered, expected in zip(filtered_transactions, expected_results[i]):
+                assert filtered.id == expected.id
+                assert filtered.merchant.name == expected.merchant.name


### PR DESCRIPTION
## Summary

Adds support for defining filters used to pre-filter the transactions that
are matched against Amazon transactions.

This is essential to prevent false-positive matches between transactions
that share a transaction dollar amount, but are not actually from Amazon.

## Configuration

To take advantage of this capability, add the following to `mmac.toml`:

```toml
[[transaction_filters]]
# The string to search for in the merchant name.
merchant_name = "amazon"

# Whether to ignore case when matching.
ignore_case = true

# Whether to search for `merchant_name` within the Monarch
# transaction, rather than requiring a complete match.
# search_by_contains = false
```

You can add multiple filters, if desired.