### PR TITLE
fix: Check for Invalid Saved Sessions at Startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug mmac",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "src.main",
+            "args": [],
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "justMyCode": true
+        }
+    ]
+}

--- a/src/monarch_connector/exceptions.py
+++ b/src/monarch_connector/exceptions.py
@@ -8,3 +8,7 @@ class CaptchaException(Exception):
 
 class OTPException(Exception):
     pass
+
+
+class InvalidMonarchSessionException(Exception):
+    pass


### PR DESCRIPTION
## Summary

Closes #12 

Invalid saved sessions are now caught at startup, instead of after Amazon order scraping.

Additionally, invalid saved sessions now result in an automatic re-authentication attempt.